### PR TITLE
chore: allow empty query for find()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ipfs
 cache
 coverage
 .aviondb
+.testdb
 .npmrc
 
 # Don't track builds in git

--- a/README.md
+++ b/README.md
@@ -38,25 +38,27 @@ This is the Javascript implementation and it works both in **Browsers** and **No
 ## Table of Contents
 
 <!-- toc -->
+- [Table of Contents](#table-of-contents)
 - [Install](#install)
   - [Using NodeJS](#using-nodejs)
   - [In a web browser](#in-a-web-browser)
-	- [In a web browser through Browserify](#through-browserify)
-	- [In a web browser through Webpack](#through-webpack)
-	- [In a web browser through CDN](#from-cdn)
+    - [**through Browserify**](#through-browserify)
+    - [**through webpack**](#through-webpack)
+    - [**from CDN**](#from-cdn)
 - [Usage](#usage)
+  - [Example](#example)
 - [API](#api)
 - [Development](#development)
-  * [Run Tests](#run-tests)
-  * [Benchmarks](#benchmarks)
+  - [Run Tests](#run-tests)
+  - [Benchmarks](#benchmarks)
 - [Specs](#specs)
 - [Community Repos](#community-repos)
 - [Frequently Asked Questions](#frequently-asked-questions)
-  * [Are there implementations in other languages?](#are-there-implementations-in-other-languages)
-  * [Where can I see your Roadmap?](#where-can-i-see-your-roadmap)
-  * [What mongodb features does aviondb support?](#what-mongodb-features-does-aviondb-support)
-  * [How can I use AvionDB in my Application?](#how-can-i-use-aviondb-in-my-application)
-  * [Other questions?](#other-questions)
+  - [Are there implementations in other languages?](#are-there-implementations-in-other-languages)
+  - [Where can I see your Roadmap?](#where-can-i-see-your-roadmap)
+  - [What mongodb features does aviondb support?](#what-mongodb-features-does-aviondb-support)
+  - [How can I use AvionDB in my Application?](#how-can-i-use-aviondb-in-my-application)
+  - [Other Questions?](#other-questions)
 - [Contributing](#contributing)
 - [Sponsors](#sponsors)
 - [License](#license)
@@ -119,8 +121,9 @@ const IPFS = require("ipfs");
 const runExample = async () => {
   const ipfs = await IPFS.create();
     
-  // Creates a db named "DatabaseName"
-  const aviondb = await AvionDB.init("DatabaseName", ipfs); 
+  // Creates a db named "DatabaseName" in the ".aviondb" directory in the project root.
+  // If no path option is defined, $HOME/.aviondb is used for the database directory (e.g. "C:/Users/John/.aviondb" or "~/.aviondb").
+  const aviondb = await AvionDB.init("DatabaseName", ipfs, { path: './.aviondb' }); 
   
   // Returns the List of database names
   await AvionDB.listDatabases()

--- a/src/core/CollectionIndex.js
+++ b/src/core/CollectionIndex.js
@@ -6,7 +6,7 @@ class CollectionIndex {
         this._index = {}
         this.loaded = false;
     }
-    async find(query, projection, options = {}, callback) {
+    async find(query = {}, projection, options = {}, callback) {
         let res = parseAndFind(query, options, this._index, false)
         return res
     }

--- a/src/core/EnvironmentAdapter.js
+++ b/src/core/EnvironmentAdapter.js
@@ -1,4 +1,4 @@
-var isBrowser=new Function("try {return this===window;}catch(e){ return false;}");
+var isBrowser = new Function("try {return this===window;}catch(e){ return false;}");
 const LevelDb = require('datastore-level');
 const DatastoreFs = require('datastore-fs');
 const Path = require('path');
@@ -6,20 +6,18 @@ const os = require('os');
 
 
 module.exports = {
-    repoPath: function(path) {
-        if(isBrowser()) {
+    repoPath: function (path) {
+        if (isBrowser()) {
             return path || "aviondb"
         } else {
             return path || Path.join(os.homedir(), '.aviondb')
         }
     },
-    datastore: function(path) {
-        if(isBrowser()) {
-           return new LevelDb(path)
+    datastore: function (path) {
+        if (isBrowser()) {
+            return new LevelDb(Path.join(path, 'db'))
         } else {
-            return new DatastoreFs(path, {
-                extension: ""
-            })
+            return new DatastoreFs(Path.join(path, 'db'))
         }
     }
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -7,7 +7,7 @@ class AvionDB extends Store {
     static async init(name, ipfs, options, orbitDbOptions) {
         let aviondb = await super.init(name, ipfs, options, orbitDbOptions);
         var buf = Buffer.from(JSON.stringify({ address: aviondb.id }));
-        await datastore.put(new Key(`/db/${name}`), buf)
+        await datastore.put(new Key(`${name}`), buf)
         return Promise.resolve(aviondb)
     }
     static async listDatabases() {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -11,7 +11,7 @@ class AvionDB extends Store {
         return Promise.resolve(aviondb)
     }
     static async listDatabases() {
-        var dbs = datastore.query({ prefix: "/db" });
+        var dbs = datastore.query({});
         var list = []
         for await (var db of dbs) {
             let arr = JSON.parse(db.value.toString()).address.split('/')

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -4,7 +4,10 @@ const { Key } = require('interface-datastore')
 var datastore = EnvironmentAdapter.datastore(EnvironmentAdapter.repoPath())
 
 class AvionDB extends Store {
-    static async init(name, ipfs, options, orbitDbOptions) {
+    static async init(name, ipfs, options = {}, orbitDbOptions) {
+        if (options.path) {
+            this.setDatabaseConfig({ path: options.path });
+        }
         let aviondb = await super.init(name, ipfs, options, orbitDbOptions);
         var buf = Buffer.from(JSON.stringify({ address: aviondb.id }));
         await datastore.put(new Key(`${name}`), buf)
@@ -15,12 +18,16 @@ class AvionDB extends Store {
         var list = []
         for await (var db of dbs) {
             let arr = JSON.parse(db.value.toString()).address.split('/')
-            list.push(arr[arr.length-1])
+            list.push(arr[arr.length - 1])
         }
         return list;
     }
     static setDatabaseConfig(options = {}) {
         datastore = EnvironmentAdapter.datastore(EnvironmentAdapter.repoPath(options.path))
+    }
+
+    static getDatabaseConfig(options = {}) {
+        return datastore;
     }
 }
 AvionDB.Collection = require('./Collection');

--- a/test/Store.spec.js
+++ b/test/Store.spec.js
@@ -4,9 +4,10 @@ const Keystore = require('orbit-db-keystore')
 const IdentityProvider = require('orbit-db-identity-provider')
 const assert = require('assert')
 const IPFS = require('ipfs')
+const Path = require('path');
 //TODO: proper fix for using ipfs in tests requiring node to be online
 
-var DefaultOptions = {};
+var DefaultOptions = { path: './.testdb' };
 // Test utils
 const {
     config,
@@ -29,11 +30,11 @@ describe("DB", function () {
         config: {
             Addresses: {
                 API: '/ip4/127.0.0.1/tcp/0',
-                "Swarm":["/ip4/0.0.0.0/tcp/0"],
+                "Swarm": ["/ip4/0.0.0.0/tcp/0"],
                 Gateway: '/ip4/0.0.0.0/tcp/0'
             },
             Bootstrap: [],
-            Discovery: { "MDNS":{"Enabled":true,"Interval":0},"webRTCStar":{"Enabled":false}} 
+            Discovery: { "MDNS": { "Enabled": true, "Interval": 0 }, "webRTCStar": { "Enabled": false } }
         },
         EXPERIMENTAL: {
             pubsub: true
@@ -53,7 +54,6 @@ describe("DB", function () {
         ipfs = await IPFS.create(ipfsConfig)
         const name = 'test-address'
         const options = Object.assign({}, DefaultOptions, { cache })
-        Store.setDatabaseConfig({ path: "./.aviondb" })
         store = await Store.init(name, ipfs, options, {
             identity: testIdentity
         })
@@ -71,11 +71,17 @@ describe("DB", function () {
         await cacheStore.open()
         await identityStore.open()
     })
-    it("List Databases", async () => { 
-        await ipfs.ready       
+    it("Get Config Path", async () => {
+        await ipfs.ready
+        assert.strictEqual(Store.getDatabaseConfig().path, Path.join(__dirname, '../.testdb', 'db'));
+    })
+
+    it("List Databases", async () => {
+        await ipfs.ready
         const databases = await Store.listDatabases()
         assert.strictEqual(arraysEqual(databases, ['test-address']), true)
     })
+
     it("Init Collection", async () => {
         await ipfs.ready
         var collection = await store.initCollection("Accounts")
@@ -88,7 +94,7 @@ describe("DB", function () {
     it("Drop Collection", async () => {
         //TODO: Create test here
     })
-    it("List Collections", async () => { 
+    it("List Collections", async () => {
         await ipfs.ready
         var collection = await store.initCollection("Users")
         await collection.insertOne({
@@ -100,17 +106,19 @@ describe("DB", function () {
 })
 
 const arraysEqual = (a, b) => {
-  if (a === b) return true;
-  if (a == null || b == null) return false;
-  if (a.length != b.length) return false;
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    if (a.length != b.length) return false;
 
-  // If you don't care about the order of the elements inside
-  // the array, you should sort both arrays here.
-  // Please note that calling sort on an array will modify that array.
-  // you might want to clone your array first.
+    // If you don't care about the order of the elements inside
+    // the array, you should sort both arrays here.
+    // Please note that calling sort on an array will modify that array.
+    // you might want to clone your array first.
 
-  for (var i = 0; i < a.length; ++i) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
+    for (var i = 0; i < a.length; ++i) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
 }
+
+


### PR DESCRIPTION
This patch lets you do a find query with `collection.find()` without needing to pass an empty object (`find({})`).