### PR TITLE
chore: allow empty query for find()

### DIFF
--- a/src/core/CollectionIndex.js
+++ b/src/core/CollectionIndex.js
@@ -6,10 +6,11 @@ class CollectionIndex {
         this._index = {}
         this.loaded = false;
     }
-    async find(query, projection, options = {}, callback) {
+    async find(query = {}, projection, options = {}, callback) {
         let res = parseAndFind(query, options, this._index, false)
         return res
     }
+
 
     async findOne(query, projection, options = {}, callback) {
         let res = parseAndFind(query, options, this._index, true)


### PR DESCRIPTION
This patch lets you do a find query with collection.find(), without the need to pass an empty object (find({})).