### PR TITLE
feat: add sort cursor method and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "webpack-cli": "^3.3.11"
   },
   "dependencies": {
+    "array-sort": "^1.0.0",
     "bson-objectid": "^1.3.0",
     "cids": "^0.8.1",
     "datastore-fs": "^1.0.0",

--- a/src/core/operators/QueryOperators.ts
+++ b/src/core/operators/QueryOperators.ts
@@ -11,7 +11,7 @@ const parseAndFind = (
     if (Object.keys(query).length === 0) {
       return docs;
     }
-    var filteredDocs = [];
+    let filteredDocs = [];
     let skipped = 0;
     options.skip = options.skip || 0;
     const condition = (len) => (options.limit ? options.limit === len : false);

--- a/src/core/operators/QueryOperators.ts
+++ b/src/core/operators/QueryOperators.ts
@@ -1,3 +1,5 @@
+import * as arrSort from "array-sort";
+
 const parseAndFind = (
   query: Object = {},
   options: any,
@@ -9,19 +11,32 @@ const parseAndFind = (
     if (Object.keys(query).length === 0) {
       return docs;
     }
-    const filteredDocs = [];
+    var filteredDocs = [];
     let skipped = 0;
     options.skip = options.skip || 0;
     const condition = (len) => (options.limit ? options.limit === len : false);
-    for (let i = 0; i < docs.length; i++) {
-      if (evaluateQuery(docs[i], query)) {
-        if (skipped >= options.skip) {
-          filteredDocs.push(docs[i]);
+    if (options.sort) {
+      Object.keys(options.sort).map((field, index) => {
+        filteredDocs = arrSort(index === 0 ? docs : filteredDocs, field, {
+          reverse: options.sort[field] === 1 ? false : true,
+        });
+      });
+      if (options.limit) {
+        return filteredDocs.splice(options.skip, options.limit);
+      } else {
+        return filteredDocs.splice(options.skip);
+      }
+    } else {
+      for (let i = 0; i < docs.length; i++) {
+        if (evaluateQuery(docs[i], query)) {
+          if (skipped >= options.skip) {
+            filteredDocs.push(docs[i]);
+          }
+          if (condition(filteredDocs.length)) {
+            return filteredDocs;
+          }
+          ++skipped;
         }
-        if (condition(filteredDocs.length)) {
-          return filteredDocs;
-        }
-        ++skipped;
       }
     }
     return filteredDocs;

--- a/test/Collection.spec.ts
+++ b/test/Collection.spec.ts
@@ -113,17 +113,43 @@ describe("Collection", function () {
     assert.strictEqual(typeof result, "object");
     assert.strictEqual(result.length, 1);
   });
-  it("Find: Limit & Skip", async () => {
+  it("Find: Sort: Ascending", async () => {
     await store.insert([
       { name: "kim", age: 35 },
       { name: "vasa", age: 22 },
     ]);
     const result = await store.find({ age: { $gt: 10 } }, null, {
+      sort: { age: 1 },
+    });
+    assert.strictEqual(typeof result, "object");
+    assert.strictEqual(result[0].name, "vasa");
+    assert.strictEqual(result[1].name, "kim");
+  });
+  it("Find: Sort: Descending", async () => {
+    await store.insert([
+      { name: "kim", age: 35 },
+      { name: "vasa", age: 22 },
+    ]);
+    const result = await store.find({ age: { $gt: 10 } }, null, {
+      sort: { age: -1 },
+    });
+    assert.strictEqual(typeof result, "object");
+    assert.strictEqual(result[0].name, "kim");
+    assert.strictEqual(result[1].name, "vasa");
+  });
+  it("Find: Limit & Skip & Sort", async () => {
+    await store.insert([
+      { name: "kim", age: 35 },
+      { name: "vasa", age: 22 },
+    ]);
+    const result = await store.find({ age: { $gt: 10 } }, null, {
+      sort: { age: 1 },
       limit: 1,
       skip: 1,
     });
     assert.strictEqual(typeof result, "object");
     assert.strictEqual(result.length, 1);
+    assert.strictEqual(result[0].name, "kim");
   });
   it("FindOne", async () => {
     await store.insertOne({ name: "kim", age: 35 });


### PR DESCRIPTION
This PR adds the `sort` cursor method which can be used as follows.

```
await store.find({ age: { $gt: 10 } }, null, {
      sort: { age: 1 },
})
```
We preferred this way of defining the `sort` functionality as we have implemented `limit` & `skip` in the same way as above. ( So as to maintain the pattern).

The reason we are passing the cursor methods as `options` (rather than chaining methods) is due to their performance issues when working with big databases. Here are some more details on the [performance issues associated with using chaining functions](https://scalegrid.io/blog/fast-paging-with-mongodb/).


License: MIT
Signed-off-by: Vaibhav Saini <vasa@dappkit.io>