### PR TITLE
chore(init): make orbitDbOptions optional

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -27,7 +27,7 @@ class AvionDB extends Store {
     name: string,
     ipfs: Ipfs,
     options: StoreOptions = {},
-    orbitDbOptions: OrbitDBOptions
+    orbitDbOptions: OrbitDBOptions = {}
   ): Promise<AvionDB> {
     if (options.path) {
       this.setDatabaseConfig({ path: options.path });


### PR DESCRIPTION
`orbitDbOptions` in `AvionDB.init()` should be optional. 